### PR TITLE
Update log4j to 2.15.0 to mitigate CVE-2021-44228

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <log4j.version>2.15.0</log4j.version>
     </properties>
 
     <dependencies>
@@ -75,17 +76,17 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.12.1</version>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.12.1</version>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.11.1</version>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>


### PR DESCRIPTION
Update log4j to version `2.15.0` to mitigate CVE-2021-44228

It is not necessary to set `log4j.formatMsgNoLookups=true` since version `2.15.0` of log4j automatically defaults the property to `false`.

This was tested in a sample Lambda function to verify that the logging still works correctly with the updated log4j version.

See for more details 
* https://www.cisa.gov/uscert/ncas/current-activity/2021/12/10/apache-releases-log4j-version-2150-address-critical-rce
* https://github.com/advisories/GHSA-jfh8-c2jp-5v3q

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

