### PR TITLE
Update dependencies (including log4j to 2.17.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.3.0</version>
+            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-shade-plugin</artifactId>
-              <version>2.4.3</version>
+              <version>3.2.4</version>
               <executions>
                   <execution>
                       <phase>package</phase>
@@ -117,7 +117,7 @@
                       <configuration>
                           <transformers>
                               <transformer
-                                      implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                                      implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
                               </transformer>
                           </transformers>
                       </configuration>
@@ -127,7 +127,7 @@
                   <dependency>
                       <groupId>com.github.edwgiz</groupId>
                       <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                      <version>2.15</version>
+                      <version>2.15.0</version>
                   </dependency>
               </dependencies>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
                   <dependency>
                       <groupId>io.github.edwgiz</groupId>
                       <artifactId>log4j-maven-shade-plugin-extensions</artifactId>
-                      <version>2.16.0</version>
+                      <version>${log4j.version}</version>
                   </dependency>
               </dependencies>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
     </properties>
 
     <dependencies>
@@ -26,12 +26,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.129</version>
+            <version>1.12.133</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.13.0</version>
+            <version>2.13.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.71.Final</version>
+            <version>4.1.72.Final</version>
         </dependency>
         <dependency>
             <groupId>com.github.wnameless.json</groupId>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
     </properties>
 
     <dependencies>
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.128</version>
+            <version>1.12.129</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -127,7 +127,7 @@
                   <dependency>
                       <groupId>com.github.edwgiz</groupId>
                       <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                      <version>2.8.1</version>
+                      <version>2.15</version>
                   </dependency>
               </dependencies>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -16,42 +16,42 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>2.2.7</version>
+            <version>3.11.0</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.11.647</version>
+            <version>1.12.128</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.9</version>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>4.0</version>
+            <version>5.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.42.Final</version>
+            <version>4.1.71.Final</version>
         </dependency>
         <dependency>
             <groupId>com.github.wnameless.json</groupId>
             <artifactId>json-flattener</artifactId>
-            <version>0.7.1</version>
+            <version>0.13.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.joschi</groupId>
@@ -61,12 +61,12 @@
         <dependency>
             <groupId>org.graylog2</groupId>
             <artifactId>gelfclient</artifactId>
-            <version>1.5.0</version>
+            <version>1.5.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.1-jre</version>
+            <version>31.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -91,7 +91,7 @@
         <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
-          <version>4.13</version>
+          <version>4.13.2</version>
           <scope>test</scope>
         </dependency>
        <dependency>

--- a/src/main/java/org/graylog/integrations/s3/S3EventProcessor.java
+++ b/src/main/java/org/graylog/integrations/s3/S3EventProcessor.java
@@ -1,7 +1,7 @@
 package org.graylog.integrations.s3;
 
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.event.S3EventNotification;
 import com.amazonaws.services.s3.model.S3Object;
 import com.google.common.base.Strings;
 import org.apache.logging.log4j.LogManager;

--- a/src/test/java/org/graylog/integrations/s3/S3EventProcessorTest.java
+++ b/src/test/java/org/graylog/integrations/s3/S3EventProcessorTest.java
@@ -1,7 +1,7 @@
 package org.graylog.integrations.s3;
 
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.event.S3EventNotification;
 import com.amazonaws.services.s3.model.S3Object;
 import org.graylog.integrations.s3.codec.S3Codec;
 import org.graylog2.gelfclient.GelfMessage;


### PR DESCRIPTION
## Overview
Update all out-of-date dependencies for `graylog-s3-lambda`.

## Motivation
Log4j-related dependencies were recently updated in #26 and #27. And, since many other dependencies are quite out-of-date, I thought now would be a good opportunity to update them.

## Details
Note that the import for `S3EventNotification.S3Event` in `S3EventProcessor` had to be updated, because the latest version of `aws-lambda-java-events` removed AWS SDK dependencies from itself. So, the `S3Event` class must be imported from the new location `com.amazonaws.services.lambda.runtime.events.models.s3` from the `aws-lambda-java-events` dependency.

See https://github.com/aws/aws-lambda-java-libs/pull/127 for details.

## Testing
I performed a test to ensure that the AWS Lambda function still appears to work with the new dependeny versions. Please also test it yourself as part of the PR review process to help ensure it is working correctly. Use `mvn clean package` to build a testable jar. See the [README](https://github.com/Graylog2/graylog-s3-lambda/blob/master/README.md) and [RELEASE](https://github.com/Graylog2/graylog-s3-lambda/blob/master/RELEASE.md) docs for more details.

## Test Plan
- Create a test S3 bucket.
- Create/configure the Lambda function and link up the bucket.
- Compile and upload the jar file to the lambda function. 
- Establish a running Graylog instance to which logs can be sent to (with a listening TCP GELF input)
- Use the TestDataGenerator to publish logs files to the S3 bucket.
- Verify that logs are successfully received within Graylog.
- Verify that the application logs (from code `LOG.info` statements) are successfully delivered to CloudWatch.

## Change Logs:
* AWS Logger Core (`aws-lambda-java-core`, `aws-lambda-java-events`)https://github.com/aws/aws-lambda-java-libs/blob/master/aws-lambda-java-core/RELEASE.CHANGELOG.md
* `aws-java-sdk-s3` https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
* `jackson-core` https://github.com/FasterXML/jackson-core/blob/2.14/release-notes/VERSION-2.x
* `guice` https://github.com/google/guice/releases
* `commons-lang3` https://commons.apache.org/proper/commons-lang/changes-report.html
* `netty-handler` https://netty.io/news/
* `guava` https://github.com/google/guava/releases
* `junit 4` https://github.com/junit-team/junit4/releases
 
## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

